### PR TITLE
Fallback to the last released version which we have the sources for.

### DIFF
--- a/lib/debase/ruby_core_source.rb
+++ b/lib/debase/ruby_core_source.rb
@@ -39,7 +39,7 @@ module Debase
       end
 
       # Look for sources that ship with gem
-      dest_dir = File.dirname(__FILE__) + "/ruby_core_source/#{ruby_dir}"
+      dest_dir = deduce_packaged_source_dir(ruby_dir)
       no_source_abort(ruby_dir) unless File.directory?(dest_dir)
 
       with_cppflags("-I" + dest_dir) {
@@ -49,6 +49,40 @@ module Debase
         end
       }
       return false
+    end
+
+    def self.deduce_packaged_source_dir(ruby_dir)
+      prefix = File.dirname(__FILE__) + '/ruby_core_source/'
+      expected_directory = prefix + ruby_dir
+      if File.directory?(expected_directory)
+        expected_directory
+      else
+        # Fallback to an older version.
+        ruby_version = Gem::Version.new(RUBY_VERSION)
+        path, = Dir.glob(prefix + 'ruby-*').
+          select { |d| File.directory?(d) }.
+          map { |d| [d, ruby_source_dir_version(d)] }.
+          sort { |(_, v1), (_, v2)| -(v1 <=> v2) }.
+          find { |(_, v)| v < ruby_version }
+
+        version = File.basename(path)
+        fallback_source_warning(ruby_dir, version)
+        path
+      end
+    end
+
+    def self.ruby_source_dir_version(dir)
+      match = /ruby-([0-9\.]+)-p([0-9]+)/.match(dir)
+      Gem::Version.new("#{match[1]}.#{match[2]}")
+    end
+
+    def self.fallback_source_warning(ruby_version, fallback_version)
+      warn <<-STR
+**************************************************************************
+No source for #{ruby_version} provided with debase-ruby_core_source gem.
+Falling back to #{fallback_version}.
+**************************************************************************
+STR
     end
 
     def self.no_source_abort(ruby_version)


### PR DESCRIPTION
This allows debase to be installed immediately after a new version of Ruby is released.

Possible extension of this would be to only fall back if the minor version matches (e.g. 2.2.3 -> 2.2.4) but not for 2.2 -> 2.3, but I think that's not too likely to happen for now.