### PR TITLE
make headers search survive src-based rubies

### DIFF
--- a/lib/debase/ruby_core_source/version.rb
+++ b/lib/debase/ruby_core_source/version.rb
@@ -1,5 +1,5 @@
 module Debase
   module RubyCoreSource
-   VERSION = '0.9.11'
+   VERSION = '0.9.12'
   end
 end


### PR DESCRIPTION
At the moment it's impossible to use debase-ruby_core_source to compile gems against ruby-head (or other src-based rubies). I want to set up testing against ruby-head on travis and this is a requirement.