### PR TITLE
in 2.7 ruby RUBY_REVISION is a hash of a commit

### DIFF
--- a/lib/debase/ruby_core_source.rb
+++ b/lib/debase/ruby_core_source.rb
@@ -50,7 +50,7 @@ module Debase
     def self.deduce_packaged_source_dir(ruby_dir)
       prefix = File.dirname(__FILE__) + '/ruby_core_source/'
       expected_directory = prefix + ruby_dir
-      if RUBY_REVISION > 0 and File.directory?(expected_directory)
+      if (RUBY_REVISION.is_a? String or RUBY_REVISION > 0) and File.directory?(expected_directory)
         expected_directory
       else
         # Fallback to an older version.


### PR DESCRIPTION
Since ruby source code repository moved to git(https://github.com/ruby/ruby/commit/5da52d1210625fb00acd573b3f32281b4bde1730), now in RUBY_REVISION variable contains a hash of the commit as string:
rb_define_global_const("RUBY_REVISION", MKSTR(revision));