### PR TITLE
FIX: the regular expression that can be matched to the wrong position.

### DIFF
--- a/lib/debase/ruby_core_source.rb
+++ b/lib/debase/ruby_core_source.rb
@@ -68,7 +68,7 @@ module Debase
     end
 
     def self.ruby_source_dir_version(dir)
-      match = /ruby-([0-9\.]+)-(.+)/.match(dir)
+      match = /ruby-([0-9\.]+)-((p|rc)[0-9]+)\z/.match(dir)
       Gem::Version.new("#{match[1]}.#{match[2]}")
     end
 


### PR DESCRIPTION
**Problems**

if directory contains another `ruby-n.n.n-something` in its name, for example, `.../ruby-1.2.3-p456/gems/debase-ruby_core_source-0.10.5/lib/debase/ruby_core_source/...`, the regular expression `/ruby-([0-9\.]+)-(.+)/` matches to the first pattern not the one for `ruby_core_source/ruby-n.n.n-something`, which fails to find ruby version from `dir`.

**Solution**

Change the regular expression more strict to only match the last part of given String to find a version.